### PR TITLE
Show cadence number on plots

### DIFF
--- a/lightkurve/targetpixelfile.py
+++ b/lightkurve/targetpixelfile.py
@@ -503,7 +503,7 @@ class TargetPixelFile(object):
         return col_centr, row_centr
 
     def plot(self, ax=None, frame=0, cadenceno=None, bkg=False, aperture_mask=None,
-             show_colorbar=True, mask_color='pink', style='lightkurve', showcadencenum=False, **kwargs):
+             show_colorbar=True, mask_color='pink', style='lightkurve', **kwargs):
         """Plot the pixel data for a single frame (i.e. at a single time).
 
         The time can be specified by frame index number (`frame=0` will show the
@@ -557,10 +557,7 @@ class TargetPixelFile(object):
             raise ValueError("frame {} is out of bounds, must be in the range "
                              "0-{}.".format(frame, self.shape[0]))
         with plt.style.context(style):
-            if showcadencenum:
-                    img_title = 'Target ID: {}, frame: {}'.format(self.targetid, frame)
-            else:
-                img_title = 'Target ID: {}'.format(self.targetid)
+            img_title = 'Target ID: {}, Cadence: {}'.format(self.targetid, self.cadenceno[frame])
             img_extent = (self.column, self.column + self.shape[2],
                           self.row, self.row + self.shape[1])
             ax = plot_image(pflux, ax=ax, title=img_title, extent=img_extent,


### PR DESCRIPTION
Now `self.cadenceno[frame]` is shown, not frame. It is shown by default.